### PR TITLE
Fix Player Counts for loot calculations

### DIFF
--- a/scripts/game_state.lua
+++ b/scripts/game_state.lua
@@ -977,7 +977,7 @@ function GameState:change(what, name, nr, amount)
 end
 
 function GameState:evalExpr(str)
-    return luaxp.evaluate(str, { L = self.level, C = self:nbCharacters() })
+    return luaxp.evaluate(str, { L = self.level, C = Global.call("getPlayerCount") })
 end
 
 function GameState:startRound(characterInitiatives)


### PR DESCRIPTION
`self:nbCharacters()` only really works if users have the internal game state enabled. As a result, there are incorrect loot amounts shown because the player count is off. I believe `Global.call("getPlayerCount")` should work no matter what kind of game state is being used