### PR TITLE
Fix s136 room 2 overlay

### DIFF
--- a/processedScenarios.human.json
+++ b/processedScenarios.human.json
@@ -21692,6 +21692,16 @@
             ],
             "overlays": [
               {
+                "name": "Large Metal Corridor",
+                "orientation": 60,
+                "positions": [
+                  {
+                    "x": 0,
+                    "y": -1
+                  }
+                ]
+              },
+              {
                 "name": "Dungeon Door",
                 "orientation": 240,
                 "positions": [


### PR DESCRIPTION
[s136 doesn't place the corridor tile at the right of the 2nd room ](https://steamcommunity.com/workshop/filedetails/discussion/2973518625/6861841362670929245/?ctp=2#c4302697675601296629)