### PR TITLE
Fix Bannerspear multi costs, 2 Trap cards

### DIFF
--- a/docs/cardEnhancements.json
+++ b/docs/cardEnhancements.json
@@ -489,6 +489,7 @@
             {
                 "ability": "move",
                 "mtype": "",
+                "multi": "multi",
                 "position": {
                     "x": -0.242,
                     "z": 1.048
@@ -499,6 +500,7 @@
                 "ability": "pull",
                 "lost": "lost",
                 "mtype": "",
+                "multi": "multi",
                 "position": {
                     "x": 0.209,
                     "z": -0.861
@@ -1257,6 +1259,7 @@
             {
                 "ability": "move",
                 "mtype": "",
+                "multi": "multi",
                 "position": {
                     "x": -0.26,
                     "z": 0.918
@@ -2762,7 +2765,7 @@
         "level": 1,
         "spots": [
             {
-                "ability": "attack",
+                "ability": "range",
                 "multi": "multi",
                 "position": {
                     "x": -0.367,
@@ -2896,6 +2899,7 @@
             {
                 "ability": "move",
                 "mtype": "",
+                "multi": "multi",
                 "position": {
                     "x": -0.284,
                     "z": 0.913
@@ -3966,6 +3970,7 @@
             {
                 "ability": "move",
                 "mtype": "",
+                "multi": "multi",
                 "position": {
                     "x": -0.265,
                     "z": 1.1
@@ -4937,6 +4942,7 @@
             {
                 "ability": "attack",
                 "mtype": "",
+                "multi": "multi",
                 "position": {
                     "x": 0.021,
                     "z": -0.988
@@ -5949,7 +5955,7 @@
                     "x": -0.254,
                     "z": 0.738
                 },
-                "type": ""
+                "type": "c"
             }
         ]
     },
@@ -6853,6 +6859,7 @@
             {
                 "ability": "move",
                 "mtype": "",
+                "multi": "multi",
                 "position": {
                     "x": -0.268,
                     "z": 1.064
@@ -7089,6 +7096,7 @@
             {
                 "ability": "attack",
                 "mtype": "",
+                "multi": "multi",
                 "position": {
                     "x": 0.132,
                     "z": -0.975
@@ -7201,6 +7209,7 @@
             {
                 "ability": "target",
                 "mtype": "",
+                "multi": "multi",
                 "position": {
                     "x": -0.147,
                     "z": 0.956


### PR DESCRIPTION
* [Trap cards: one wrongly listed as attack (should be range), another failed to specify enhancement type](https://steamcommunity.com/workshop/filedetails/discussion/2973518625/6861841362670931616/#c4302697675600506464)
* [Bannerspear cards missing multi-target cost](https://steamcommunity.com/workshop/filedetails/discussion/2973518625/6861841362670931616/#c4302697675601086623)